### PR TITLE
updated 'organization' parameter for openai completion module 

### DIFF
--- a/app/chatbot.py
+++ b/app/chatbot.py
@@ -8,6 +8,7 @@ import yaml
 with open('./app/static/secret.yaml') as file:
     secret_keys = yaml.load(file, Loader=yaml.FullLoader)
 openai.api_key = secret_keys["openai"]
+openai.organization = 'org-FYH4qiS0WzXH7l0pCbezhmat' ## UofT Organization
 completion = openai.Completion()
 
 start_sequence = "\nAI:"


### PR DESCRIPTION
Basically it controls which organization is used when making requests with the API keys. For members of the org that are part of multiple organizations. Organization code can be found under 'Settings' tab: 

<img width="935" alt="image" src="https://user-images.githubusercontent.com/72905894/204324045-fb030c1a-d69b-40d4-84f6-fcde10e65384.png">
